### PR TITLE
remove prefixes from response for sync requests

### DIFF
--- a/src/main/java/com/khomishchak/ws/controllers/ExchangerController.java
+++ b/src/main/java/com/khomishchak/ws/controllers/ExchangerController.java
@@ -52,12 +52,12 @@ public class ExchangerController {
     }
 
     @PostMapping("/synchronize/balance")
-    public SyncBalancesResp synchronizeBalanceDataForUser(@RequestHeader("UserId") Long userId) {
+    public List<Balance> synchronizeBalanceDataForUser(@RequestHeader("UserId") Long userId) {
         return exchangerService.synchronizeBalanceDataForUser(userId);
     }
 
     @PostMapping("/deposit-withdrawal-history/synchronize")
-    public SyncDepositWithdrawalTransactionsResp synchronizeDWTransactionsHistory(@RequestHeader("UserId") Long userId) {
+    public List<ExchangerDepositWithdrawalTransactions> synchronizeDWTransactionsHistory(@RequestHeader("UserId") Long userId) {
         return exchangerService.synchronizeDepositWithdrawalTransactionsData(userId);
     }
 

--- a/src/main/java/com/khomishchak/ws/controllers/ExchangerController.java
+++ b/src/main/java/com/khomishchak/ws/controllers/ExchangerController.java
@@ -6,8 +6,6 @@ import com.khomishchak.ws.model.exchanger.ExchangerUniqueCurrenciesDTO;
 import com.khomishchak.ws.model.exchanger.transaction.ExchangerDepositWithdrawalTransactions;
 import com.khomishchak.ws.model.requests.RegisterExchangerInfoReq;
 import com.khomishchak.ws.model.response.FirstlyGeneratedBalanceResp;
-import com.khomishchak.ws.model.response.SyncBalancesResp;
-import com.khomishchak.ws.model.response.SyncDepositWithdrawalTransactionsResp;
 import com.khomishchak.ws.services.exchangers.ExchangerService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/khomishchak/ws/model/response/SyncBalancesResp.java
+++ b/src/main/java/com/khomishchak/ws/model/response/SyncBalancesResp.java
@@ -1,8 +1,0 @@
-package com.khomishchak.ws.model.response;
-
-import com.khomishchak.ws.model.exchanger.Balance;
-
-import java.util.List;
-
-public record SyncBalancesResp() {
-}

--- a/src/main/java/com/khomishchak/ws/model/response/SyncBalancesResp.java
+++ b/src/main/java/com/khomishchak/ws/model/response/SyncBalancesResp.java
@@ -4,5 +4,5 @@ import com.khomishchak.ws.model.exchanger.Balance;
 
 import java.util.List;
 
-public record SyncBalancesResp(List<Balance> synchronizedBalances) {
+public record SyncBalancesResp() {
 }

--- a/src/main/java/com/khomishchak/ws/model/response/SyncDepositWithdrawalTransactionsResp.java
+++ b/src/main/java/com/khomishchak/ws/model/response/SyncDepositWithdrawalTransactionsResp.java
@@ -1,8 +1,0 @@
-package com.khomishchak.ws.model.response;
-
-import com.khomishchak.ws.model.exchanger.transaction.ExchangerDepositWithdrawalTransactions;
-
-import java.util.List;
-
-public record SyncDepositWithdrawalTransactionsResp() {
-}

--- a/src/main/java/com/khomishchak/ws/model/response/SyncDepositWithdrawalTransactionsResp.java
+++ b/src/main/java/com/khomishchak/ws/model/response/SyncDepositWithdrawalTransactionsResp.java
@@ -4,5 +4,5 @@ import com.khomishchak.ws.model.exchanger.transaction.ExchangerDepositWithdrawal
 
 import java.util.List;
 
-public record SyncDepositWithdrawalTransactionsResp(List<ExchangerDepositWithdrawalTransactions> transactions) {
+public record SyncDepositWithdrawalTransactionsResp() {
 }

--- a/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerService.java
+++ b/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerService.java
@@ -6,8 +6,6 @@ import com.khomishchak.ws.model.exchanger.ExchangerUniqueCurrenciesDTO;
 import com.khomishchak.ws.model.exchanger.transaction.ExchangerDepositWithdrawalTransactions;
 import com.khomishchak.ws.model.requests.RegisterExchangerInfoReq;
 import com.khomishchak.ws.model.response.FirstlyGeneratedBalanceResp;
-import com.khomishchak.ws.model.response.SyncBalancesResp;
-import com.khomishchak.ws.model.response.SyncDepositWithdrawalTransactionsResp;
 
 import java.util.List;
 

--- a/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerService.java
+++ b/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerService.java
@@ -22,8 +22,8 @@ public interface ExchangerService {
 
     List<ExchangerDepositWithdrawalTransactions> getWithdrawalDepositWalletHistory(long userId);
 
-    SyncBalancesResp synchronizeBalanceDataForUser(long userId);
-    SyncDepositWithdrawalTransactionsResp synchronizeDepositWithdrawalTransactionsData(long userId);
+    List<Balance> synchronizeBalanceDataForUser(long userId);
+    List<ExchangerDepositWithdrawalTransactions> synchronizeDepositWithdrawalTransactionsData(long userId);
 
     void deleteExchangerForUser(long balanceId);
 

--- a/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerServiceImpl.java
+++ b/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerServiceImpl.java
@@ -11,8 +11,6 @@ import com.khomishchak.ws.model.exchanger.transaction.ExchangerDepositWithdrawal
 import com.khomishchak.ws.model.requests.RegisterApiKeysReq;
 import com.khomishchak.ws.model.requests.RegisterExchangerInfoReq;
 import com.khomishchak.ws.model.response.FirstlyGeneratedBalanceResp;
-import com.khomishchak.ws.model.response.SyncBalancesResp;
-import com.khomishchak.ws.model.response.SyncDepositWithdrawalTransactionsResp;
 import com.khomishchak.ws.repositories.ApiKeySettingRepository;
 import com.khomishchak.ws.services.UserService;
 import com.khomishchak.ws.services.exchangers.balances.BalanceService;

--- a/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerServiceImpl.java
+++ b/src/main/java/com/khomishchak/ws/services/exchangers/ExchangerServiceImpl.java
@@ -72,14 +72,13 @@ public class ExchangerServiceImpl implements ExchangerService {
     }
 
     @Override
-    public SyncBalancesResp synchronizeBalanceDataForUser(long userId) {
-        return new SyncBalancesResp(balanceService.synchronizeBalances(userId));
+    public List<Balance> synchronizeBalanceDataForUser(long userId) {
+        return balanceService.synchronizeBalances(userId);
     }
 
     @Override
-    public SyncDepositWithdrawalTransactionsResp synchronizeDepositWithdrawalTransactionsData(long userId) {
-        return new SyncDepositWithdrawalTransactionsResp(
-                accountBalanceTransferOperationsHistoryService.synchronizeDepositWithdrawalTransactionsHistory(userId));
+    public List<ExchangerDepositWithdrawalTransactions> synchronizeDepositWithdrawalTransactionsData(long userId) {
+        return accountBalanceTransferOperationsHistoryService.synchronizeDepositWithdrawalTransactionsHistory(userId);
     }
 
     @Override

--- a/src/test/java/com/khomishchak/ws/services/exchangers/ExchangerServiceImplTest.java
+++ b/src/test/java/com/khomishchak/ws/services/exchangers/ExchangerServiceImplTest.java
@@ -9,8 +9,6 @@ import com.khomishchak.ws.model.exchanger.transaction.ExchangerDepositWithdrawal
 import com.khomishchak.ws.model.requests.RegisterApiKeysReq;
 import com.khomishchak.ws.model.requests.RegisterExchangerInfoReq;
 import com.khomishchak.ws.model.response.FirstlyGeneratedBalanceResp;
-import com.khomishchak.ws.model.response.SyncBalancesResp;
-import com.khomishchak.ws.model.response.SyncDepositWithdrawalTransactionsResp;
 import com.khomishchak.ws.repositories.ApiKeySettingRepository;
 import com.khomishchak.ws.services.UserService;
 import com.khomishchak.ws.services.exchangers.balances.BalanceService;
@@ -151,10 +149,9 @@ class ExchangerServiceImplTest {
         when(balanceService.synchronizeBalances(eq(USER_ID))).thenReturn(List.of(firstSyncBalance, secondSyncBalance));
 
         // when
-        SyncBalancesResp result = exchangerService.synchronizeBalanceDataForUser(USER_ID);
+        List<Balance> resultBalances = exchangerService.synchronizeBalanceDataForUser(USER_ID);
 
         // then
-        List<Balance> resultBalances = result.synchronizedBalances();
         assertThat(resultBalances.size()).isEqualTo(2);
         assertThat(resultBalances.get(0)).isEqualTo(firstSyncBalance);
         assertThat(resultBalances.get(1)).isEqualTo(secondSyncBalance);
@@ -170,12 +167,12 @@ class ExchangerServiceImplTest {
                 .thenReturn(List.of(transactions));
 
         // when
-        SyncDepositWithdrawalTransactionsResp result = exchangerService.synchronizeDepositWithdrawalTransactionsData(USER_ID);
+        List<ExchangerDepositWithdrawalTransactions> result =
+                exchangerService.synchronizeDepositWithdrawalTransactionsData(USER_ID);
 
         // then
-        List<ExchangerDepositWithdrawalTransactions> resultBalances = result.transactions();
-        assertThat(resultBalances.size()).isEqualTo(1);
-        assertThat(resultBalances.get(0)).isEqualTo(transactions);
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0)).isEqualTo(transactions);
     }
 
     @Test


### PR DESCRIPTION
in order to simplify work for FE I removed prefixes from sync request responses now FE will have the same resp body for both: local(cache) and remote(exchangers) requests